### PR TITLE
Build in generic executor

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -6,7 +6,7 @@ NVCC_FLAGS=-ccbin=icpc -t 4
 
 # TODO: static may need to be added later or independently just for benchmarks, while libs to link through python are probably going to need to be dynamic.
 NVCC_FLAGS+=--cudart=static
-NVCC_FLAGS+=--default-stream per-thread -m64 -O3 --use_fast_math --extra-device-vectorization -std=c++17 -Xptxas --warn-on-local-memory-usage,--warn-on-spills, --generate-line-info -Xcompiler=-std=c++17
+NVCC_FLAGS+=--default-stream per-thread -m64 -O3 --use_fast_math --extra-device-vectorization --extended-lambda -std=c++17 -Xptxas --warn-on-local-memory-usage,--warn-on-spills, --generate-line-info -Xcompiler=-std=c++17
 # Experimental flag to allow relaxed constexpr host call in device code
 NVCC_FLAGS+=--expt-relaxed-constexpr
 # For testing, particularly until the cufftdx::BlockDim() operator is enabled

--- a/docs/_docs/MS/manuscript.md
+++ b/docs/_docs/MS/manuscript.md
@@ -146,6 +146,18 @@ By design, the cufft library from Nvidia returns an FFT in the natural order [TO
 | 1024 | 1.85 | 2.25 | | 1.79 | 2.43 |
 | 2048 | 1.95 | 1.95 | | 2.10| 2.10|
 
+*with a generic lambda*
+
+| 2D input | 2x size |  4096 | <- sm70 sm86 -> |2x size |  4096 |
+| --- | ---- | ---- | --- | ---- | ---- |
+| 32 | 2.31 | 2.52 | | 2.39 | 2.65 |
+| 64 | 2.54 | 2.61 | | 2.78 | 2.73 |
+| 128 | 2.29 | 2.64 | | 2.36 | 2.74 |
+| 256 | 1.59 | 2.50 |   | 1.63 | 2.71 |
+| 512 | 1.34 | 2.50 | | 1.32 | 2.63 |
+| 1024 | 1.90 | 2.30 | | 1.80 | 2.46 |
+| 2048 | 1.95 | 1.95 | | 2.10| 2.10|
+
 ##### Table 3: cuFFT/FastFFT runtime (sm70) zero padded convolution of input size (top row), where only (bottom row) pixel sq. is needed for output
 
 | | 32   |64   | 128 | 256 | 512 | 1024| 2048| 4096|

--- a/include/FastFFT.h
+++ b/include/FastFFT.h
@@ -227,7 +227,7 @@ public:
         };
     */
     template<class FunctionType>
-    void Generic_Fwd_Op_Inv(ComputeType* data, FunctionType user_lambda);
+    void Generic_Fwd_Op_Inv(float2* data, FunctionType user_lambda);
 
     void ClipIntoTopLeft();
     void ClipIntoReal(int wanted_coordinate_of_box_center_x, int wanted_coordinate_of_box_center_y, int wanted_coordinate_of_box_center_z);

--- a/include/FastFFT.h
+++ b/include/FastFFT.h
@@ -216,35 +216,44 @@ public:
   void CrossCorrelate(float2* image_to_search, bool swap_real_space_quadrants);
   void CrossCorrelate(__half2* image_to_search, bool swap_real_space_quadrants);
 
-  void ClipIntoTopLeft();
-  void ClipIntoReal(int wanted_coordinate_of_box_center_x, int wanted_coordinate_of_box_center_y, int wanted_coordinate_of_box_center_z);
+    /*
+    Could be Generic_op_Fwd_op_Inv_op, where Fwd/Inv refer to the FFT/IFFT. and op refers to a user defined operation defined in a lambda.
 
-  // For all real valued inputs, assumed for any InputType that is not float2 or __half2
+    For the time being, this is assumed to not capture anything (stateless).
+    TODO: verify statelessness.
+    
+            auto test_lambda = [] __device__ (float in) {
+            printf("%f\n", in);
+        };
+    */
+    template<class FunctionType>
+    void Generic_Fwd_Op_Inv(ComputeType* data, FunctionType user_lambda);
 
-  int inline ReturnInputMemorySize() { return input_memory_allocated; }
-  int inline ReturnFwdOutputMemorySize() { return fwd_output_memory_allocated; }
-  int inline ReturnInvOutputMemorySize() { return inv_output_memory_allocated; }
+    void ClipIntoTopLeft();
+    void ClipIntoReal(int wanted_coordinate_of_box_center_x, int wanted_coordinate_of_box_center_y, int wanted_coordinate_of_box_center_z);
 
-  short4 inline ReturnFwdInputDimensions() { return fwd_dims_in; }
-  short4 inline ReturnFwdOutputDimensions() { return fwd_dims_out; }
-  short4 inline ReturnInvInputDimensions() { return inv_dims_in; }
-  short4 inline ReturnInvOutputDimensions() { return inv_dims_out; }
+    // For all real valued inputs, assumed for any InputType that is not float2 or __half2
 
-  template<typename T, bool is_on_host = true>
-  void SetToConstant(T* input_pointer, int N_values, const T& wanted_value)
-  {
-    if (is_on_host) 
-    {
-      for (int i = 0; i < N_values; i++)
-      {
-        input_pointer[i] = wanted_value;
-      }
+    int inline ReturnInputMemorySize() { return input_memory_allocated; }
+    int inline ReturnFwdOutputMemorySize() { return fwd_output_memory_allocated; }
+    int inline ReturnInvOutputMemorySize() { return inv_output_memory_allocated; }
+
+    short4 inline ReturnFwdInputDimensions() { return fwd_dims_in; }
+    short4 inline ReturnFwdOutputDimensions() { return fwd_dims_out; }
+    short4 inline ReturnInvInputDimensions() { return inv_dims_in; }
+    short4 inline ReturnInvOutputDimensions() { return inv_dims_out; }
+
+    template<typename T, bool is_on_host = true>
+    void SetToConstant(T* input_pointer, int N_values, const T& wanted_value) {
+        if (is_on_host)  {
+            for (int i = 0; i < N_values; i++) {
+                input_pointer[i] = wanted_value;
+            }
+        }
+        else {
+            exit(-1);
+        }
     }
-    else
-    {
-      exit(-1);
-    }
-  }
 
   template<typename T, bool is_on_host = true>
   void SetToRandom(T* input_pointer, int N_values, const T& wanted_mean, const T& wanted_stddev)
@@ -316,8 +325,9 @@ public:
     std::cout << "transform stage complete " << TransformStageCompletedName[transform_stage_completed] << std::endl;
     std::cout << "input_origin_type " << OriginTypeName[input_origin_type] << std::endl;
     std::cout << "output_origin_type " << OriginTypeName[output_origin_type] << std::endl;
-    
+ 
   }; // PrintState()
+
 
 private:
 
@@ -413,7 +423,8 @@ private:
                     xcorr_fwd_decrease_inv_none, // (e.g. Fourier cropping)
                     xcorr_fwd_none_inv_decrease, // (e.g. movie/particle translational search)
                     xcorr_fwd_decrease_inv_decrease, // (e.g. bandlimit, xcorr, translational search)
-                    xcorr_decomposed }; // Used to specify the origin of the data
+                    xcorr_decomposed,
+                    generic_fwd_none_op_inv_decrease }; 
   // WARNING this is flimsy and prone to breaking, you must ensure the order matches the KernelType enum.
   std::vector<std::string> 
         KernelName{ "r2c_decomposed", 
@@ -430,7 +441,8 @@ private:
                     "xcorr_fwd_decrease_inv_none",
                     "xcorr_fwd_none_inv_decrease",
                     "xcorr_fwd_decrease_inv_decrease",
-                    "xcorr_decomposed" };
+                    "xcorr_decomposed",
+                    "generic_fwd_none_op_inv_decrease" };
 
   inline bool IsThreadType(KernelType kernel_type)
   {
@@ -449,7 +461,8 @@ private:
              kernel_type == c2c_inv_none || kernel_type == c2c_inv_none_XZ || kernel_type == c2c_inv_none_Z ||
              kernel_type == c2c_inv_decrease || kernel_type == c2c_inv_increase ||
              kernel_type == c2r_none || kernel_type == c2r_none_XY || kernel_type == c2r_decrease || kernel_type == c2r_increase ||
-             kernel_type == xcorr_fwd_increase_inv_none || kernel_type == xcorr_fwd_decrease_inv_none || kernel_type == xcorr_fwd_none_inv_decrease || kernel_type == xcorr_fwd_decrease_inv_decrease)
+             kernel_type == xcorr_fwd_increase_inv_none || kernel_type == xcorr_fwd_decrease_inv_none || kernel_type == xcorr_fwd_none_inv_decrease || kernel_type == xcorr_fwd_decrease_inv_decrease ||
+             kernel_type == generic_fwd_none_op_inv_decrease)
     { 
       return false;
     }
@@ -492,7 +505,8 @@ private:
           kernel_type == c2c_fwd_none || kernel_type == c2c_fwd_none_Z || kernel_type == c2c_fwd_increase_Z ||
           kernel_type == c2c_fwd_decrease || 
           kernel_type == c2c_fwd_increase || 
-          kernel_type == xcorr_fwd_decrease_inv_none || kernel_type == xcorr_fwd_increase_inv_none)
+          kernel_type == xcorr_fwd_decrease_inv_none || kernel_type == xcorr_fwd_increase_inv_none ||
+          kernel_type == generic_fwd_none_op_inv_decrease)
 
     {
       return true;
@@ -560,22 +574,25 @@ private:
   template<class FFT, class invFFT> void FFT_C2C_WithPadding_ConjMul_C2C_t(float2* image_to_search, bool swap_real_space_quadrants);
   template<class FFT, class invFFT> void FFT_C2C_decomposed_ConjMul_C2C_t(float2* image_to_search, bool swap_real_space_quadrants);
 
+    // auto x = [](const auto&) { return true; }
+    // template<typename T, typename U = decltype(x)> void f(U u = x);
+
   // 1. 
   // First call passed from a public transform function, selects block or thread and the transform precision.
-  template <bool use_thread_method = false>
-  void SetPrecisionAndExectutionMethod(KernelType kernel_type, bool do_forward_transform = true);
+  template <bool use_thread_method = false, class FunctionType = double> // bool is just used as a dummy type
+  void SetPrecisionAndExectutionMethod(KernelType kernel_type, bool do_forward_transform = true, FunctionType user_lambda = ([]__device__ ()->double{ return double(0.0); })());
 
   // 2.
   // Second call, sets size of the transform kernel, selects the appropriate GPU arch
-  template <class FFT_base>
-  void SelectSizeAndType(KernelType kernel_type, bool do_forward_transform);
+  template <class FFT_base, class FunctionType = double>
+  void SelectSizeAndType(KernelType kernel_type, bool do_forward_transform, FunctionType user_lambda = ([]__device__ ()->double { return double(0.0); })());
 
-  template <class FFT_base>
-  void SelectSizeAndType_3d(KernelType kernel_type, bool do_forward_transform);
+//   template <class FFT_base, class FunctionType>
+//   void SelectSizeAndType_3d(KernelType kernel_type, FunctionType  user_lambda = default_lambda, bool do_forward_transform);
   // 3.
   // Third call, sets the input and output dimensions and type
-  template <class FFT_base_arch, bool use_thread_method = false>
-  void SetAndLaunchKernel(KernelType kernel_type, bool do_forward_transform);
+  template <class FFT_base_arch, class FunctionType = double, bool use_thread_method = false>
+  void SetAndLaunchKernel(KernelType kernel_type, bool do_forward_transform, FunctionType user_lambda = ([]__device__ ()->double { return double(0.0); })());
 
 
 

--- a/src/FastFFT.cu
+++ b/src/FastFFT.cu
@@ -821,7 +821,7 @@ void FourierTransformer<ComputeType, InputType, OutputType>::CrossCorrelate(__ha
 
 template <class ComputeType, class InputType, class OutputType>
 template <class FunctionType>
-void FourierTransformer<ComputeType, InputType, OutputType>::Generic_Fwd_Op_Inv(ComputeType* image_to_search, FunctionType user_lambda) {
+void FourierTransformer<ComputeType, InputType, OutputType>::Generic_Fwd_Op_Inv(float2* image_to_search, FunctionType user_lambda) {
 
     // Set the member pointer to the passed pointer
     d_ptr.image_to_search = image_to_search;

--- a/src/tests/test.cu
+++ b/src/tests/test.cu
@@ -927,24 +927,25 @@ void compare_libraries(std::vector<int>size, bool do_3d, int size_change_type) {
         cuFFT_output.MakeCufftPlan();
       }
 
-    //   std::cout << "Test lambda" << std::endl;
-    //   // Create a no capture lambda function. Target FFT is the pre-transformed image to search.
-    //   // template FFT will come from *this.
-    //   auto conj_mul_lambda = [] __device__ (__float2 template_fft, __float2 target_fft))) {
-    //       // Is there a better way than declaring this variable each time?
-    //       float tmp  = (template_fft.x * target_fft.x + template_fft.y * target_fft.y); 
-    //       template.y =  (template_fft.y * target_fft.x - template_fft.x * target_fft.y) ;
-    //       template.x = tmp;
-    //   };
-    //   // Will type deduction work here?
-    //   FT.Generic_Fwd_Op_Inv(targetFT.d_ptr.momentum_space, conj_mul_lambda);
+      std::cout << "Test lambda" << std::endl;
+      // Create a no capture lambda function. Target FFT is the pre-transformed image to search.
+      // template FFT will come from *this.
+      auto conj_mul_lambda = [] __device__ (float2 template_fft, float2 target_fft) {
+          // Is there a better way than declaring this variable each time?
+          float tmp  = (template_fft.x * target_fft.x + template_fft.y * target_fft.y); 
+          template_fft.y =  (template_fft.y * target_fft.x - template_fft.x * target_fft.y) ;
+          template_fft.x = tmp;
+      };
+
 
       //////////////////////////////////////////
       //////////////////////////////////////////
       // Warm up and check for accuracy
       if (set_conjMult_callback || is_size_change_decrease ) // we set set_conjMult_callback = false 
       {
-        FT.CrossCorrelate(targetFT.d_ptr.momentum_space, false);
+        // FT.CrossCorrelate(targetFT.d_ptr.momentum_space, false);
+            // Will type deduction work here?
+        FT.Generic_Fwd_Op_Inv(targetFT.d_ptr.momentum_space, conj_mul_lambda);
       }
       else
       {
@@ -1148,7 +1149,9 @@ void compare_libraries(std::vector<int>size, bool do_3d, int size_change_type) {
       {
         if (set_conjMult_callback || is_size_change_decrease )
         {
-          FT.CrossCorrelate(targetFT.d_ptr.momentum_space_buffer, false);
+        //   FT.CrossCorrelate(targetFT.d_ptr.momentum_space_buffer, false);
+        // Will type deduction work here?
+        FT.Generic_Fwd_Op_Inv(targetFT.d_ptr.momentum_space, conj_mul_lambda);          
         }
         else
         {

--- a/src/tests/test.cu
+++ b/src/tests/test.cu
@@ -176,7 +176,7 @@ bool const_image_test(std::vector<int> size, bool do_3d = false) {
     
     // Just to make sure we don't get a false positive, set the host memory to some undesired value.
     FT.SetToConstant<float>(host_output.real_values, host_output.real_memory_allocated, 2.0f);
-    
+
     // This method will call the regular FFT kernels given the input/output dimensions are equal when the class is instantiated.
     bool swap_real_space_quadrants = false;
     FT.FwdFFT(swap_real_space_quadrants);
@@ -927,7 +927,17 @@ void compare_libraries(std::vector<int>size, bool do_3d, int size_change_type) {
         cuFFT_output.MakeCufftPlan();
       }
 
-
+    //   std::cout << "Test lambda" << std::endl;
+    //   // Create a no capture lambda function. Target FFT is the pre-transformed image to search.
+    //   // template FFT will come from *this.
+    //   auto conj_mul_lambda = [] __device__ (__float2 template_fft, __float2 target_fft))) {
+    //       // Is there a better way than declaring this variable each time?
+    //       float tmp  = (template_fft.x * target_fft.x + template_fft.y * target_fft.y); 
+    //       template.y =  (template_fft.y * target_fft.x - template_fft.x * target_fft.y) ;
+    //       template.x = tmp;
+    //   };
+    //   // Will type deduction work here?
+    //   FT.Generic_Fwd_Op_Inv(targetFT.d_ptr.momentum_space, conj_mul_lambda);
 
       //////////////////////////////////////////
       //////////////////////////////////////////
@@ -1431,8 +1441,8 @@ int main(int argc, char** argv) {
     }   
 
     if (run_2d_unit_tests) {
-        if (! const_image_test (test_size_3d, false)) return 1;
-        if (! unit_impulse_test(test_size_3d, false, true)) return 1;
+        if (! const_image_test (test_size, false)) return 1;
+        if (! unit_impulse_test(test_size, false, true)) return 1;
     }
 
     if (run_3d_unit_tests) {


### PR DESCRIPTION
You can now pass in a generic lambda that is executed in between an FFT/iFFT pair

(only in c++, haven't tried to do this from python, but should work. for captureless lambdas)

Only implemented FourierTransformer::Generic_Fwd_Op_Inv
and
block_fft_kernel_C2C_FWD_INCREASE_OP_INV_NONE

Eventually have permutations of 
Op_Fwd_SIZECHANGE_OP_INV_SIZECHANGE_OP
